### PR TITLE
Support non-numeric one-time codes

### DIFF
--- a/Sources/OneTimeCodeTextField/OneTimeCodeTextField.swift
+++ b/Sources/OneTimeCodeTextField/OneTimeCodeTextField.swift
@@ -5,7 +5,7 @@ public class OneTimeCodeTextField: UITextField {
     private(set) var digitLabels = [UILabel]()
     
     // MARK: Delegates
-    private lazy var oneTimeCodeDelegate = OneTimeCodeTextFieldDelegate(oneTimeCodeTextField: self)
+    public lazy var oneTimeCodeDelegate = OneTimeCodeTextFieldDelegate(oneTimeCodeTextField: self)
     
     // MARK: Properties
     private var isConfigured = false

--- a/Sources/OneTimeCodeTextField/OneTimeCodeTextFieldDelegate.swift
+++ b/Sources/OneTimeCodeTextField/OneTimeCodeTextFieldDelegate.swift
@@ -1,14 +1,17 @@
 import UIKit
 
-class OneTimeCodeTextFieldDelegate: NSObject, UITextFieldDelegate {
+public class OneTimeCodeTextFieldDelegate: NSObject, UITextFieldDelegate {
+
+    public var allowedCharacters: CharacterSet = .decimalDigits
+
     let oneTimeCodeTextField: OneTimeCodeTextField
     
     init(oneTimeCodeTextField: OneTimeCodeTextField) {
         self.oneTimeCodeTextField = oneTimeCodeTextField
     }
     
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: string)),
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard allowedCharacters.isSuperset(of: CharacterSet(charactersIn: string)),
               let characterCount = textField.text?.count else { return false }
         return characterCount < oneTimeCodeTextField.digitLabels.count || string == ""
     }


### PR DESCRIPTION
(Fixes issue #1)

* Declared the `OneTimeCodeTextFieldDelegate` class and `OneTimeCodeTextField.oneTimeCodeDelegate` property public, and added an `OneTimeCodeTextFieldDelegate,allowedCharacters` property so that non-numeric codes can be used.

To use it, add a line like the following after the `OneTimeCodeTextField` has been configured:
```swift
<field>.oneTimeCodeDelegate.allowedCharacters = CharacterSet.alphanumerics
```

You should also specify which corresponding keyboard should be shown, like

```swift
<field>.keyboardType = .asciiCapable
```